### PR TITLE
Catch exception thrown from sleep() in the Distributed watcher

### DIFF
--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -12,12 +12,12 @@ This documents notable changes in DistributedNext.jl. The format is based on
 ### Fixed
 - Fixed a cause of potential hangs when exiting the process ([#16]).
 
-## [v1.0.0] - 2024-12-02
-
 ### Added
 - A watcher mechanism has been added to detect when both the Distributed stdlib
   and DistributedNext may be active and adding workers. This should help prevent
   incompatibilities from both libraries being used simultaneously ([#10]).
+
+## [v1.0.0] - 2024-12-02
 
 ### Fixed
 - Fixed behaviour of `isempty(::RemoteChannel)`, which previously had the

--- a/src/DistributedNext.jl
+++ b/src/DistributedNext.jl
@@ -142,8 +142,14 @@ function __init__()
             if _check_distributed_active()
                 return
             end
-    
-            sleep(1)
+
+            try
+                sleep(1)
+            catch
+                # sleep() may throw when the internal object it waits on is closed
+                # as the process exits.
+                return
+            end
         end
         errormonitor(watcher_task)
     end


### PR DESCRIPTION
Also fixed the changelog in 3bb5e66.