### PR TITLE
Enable the SSHManager tests on 32-bit platforms

### DIFF
--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,6 +7,11 @@ CurrentModule = DistributedNext
 This documents notable changes in DistributedNext.jl. The format is based on
 [Keep a Changelog](https://keepachangelog.com).
 
+## Unreleased
+
+### Fixed
+- Fixed a cause of potential hangs when exiting the process ([#16]).
+
 ## [v1.0.0] - 2024-12-02
 
 ### Added

--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -712,17 +712,9 @@ function create_worker(manager, wconfig)
     send_msg_now(w, MsgHeader(RRID(0,0), ntfy_oid), join_message)
 
     errormonitor(@async manage(w.manager, w.id, w.config, :register))
+
     # wait for rr_ntfy_join with timeout
-    timedout = false
-    errormonitor(
-        @async begin
-            sleep($timeout)
-            timedout = true
-            put!(rr_ntfy_join, 1)
-        end
-    )
-    wait(rr_ntfy_join)
-    if timedout
+    if timedwait(() -> isready(rr_ntfy_join), timeout) === :timed_out
         error("worker did not connect within $timeout seconds")
     end
     lock(client_refs) do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,8 +8,8 @@ include(joinpath(Sys.BINDIR, "..", "share", "julia", "test", "testenv.jl"))
 
 cmd = `$test_exename $test_exeflags`
 
-# LibSSH.jl currently only works on 64bit unixes
-if Sys.isunix() && Sys.WORD_SIZE == 64
+# LibSSH.jl currently only works on unixes
+if Sys.isunix()
     # Run the SSH tests with a single thread because LibSSH.jl is not thread-safe
     sshtestfile = joinpath(@__DIR__, "sshmanager.jl")
     run(addenv(`$cmd $sshtestfile`, "JULIA_NUM_THREADS" => "1"))


### PR DESCRIPTION
LibSSH.jl should now work on 32-bit.