### PR TITLE
Revise support and worker state callbacks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,9 +7,16 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
+[weakdeps]
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
+
+[extensions]
+ReviseExt = "Revise"
+
 [compat]
 Distributed = "1"
 Random = "1"
+Revise = "3.6.5"
 Serialization = "1"
 Sockets = "1"
 julia = "1.9"
@@ -21,4 +28,4 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["LinearAlgebra", "Test", "LibSSH", "Distributed"]
+test = ["LinearAlgebra", "Test", "LibSSH", "Distributed", "Revise"]

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -17,6 +17,7 @@ This documents notable changes in DistributedNext.jl. The format is based on
   and DistributedNext may be active and adding workers. This should help prevent
   incompatibilities from both libraries being used simultaneously ([#10]).
 - Implemented callback support for workers being added/removed etc ([#17]).
+- Added a package extension to support Revise.jl ([#17]).
 
 ## [v1.0.0] - 2024-12-02
 

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -16,6 +16,7 @@ This documents notable changes in DistributedNext.jl. The format is based on
 - A watcher mechanism has been added to detect when both the Distributed stdlib
   and DistributedNext may be active and adding workers. This should help prevent
   incompatibilities from both libraries being used simultaneously ([#10]).
+- Implemented callback support for workers being added/removed etc ([#17]).
 
 ## [v1.0.0] - 2024-12-02
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -50,6 +50,17 @@ DistributedNext.cluster_cookie()
 DistributedNext.cluster_cookie(::Any)
 ```
 
+## Callbacks
+
+```@docs
+DistributedNext.add_worker_added_callback
+DistributedNext.remove_worker_added_callback
+DistributedNext.add_worker_exiting_callback
+DistributedNext.remove_worker_exiting_callback
+DistributedNext.add_worker_exited_callback
+DistributedNext.remove_worker_exited_callback
+```
+
 ## Cluster Manager Interface
 
 This interface provides a mechanism to launch and manage Julia workers on different cluster environments.

--- a/ext/ReviseExt.jl
+++ b/ext/ReviseExt.jl
@@ -1,0 +1,30 @@
+module ReviseExt
+
+import DistributedNext
+import DistributedNext: myid, workers, remotecall
+
+import Revise
+
+
+struct DistributedNextWorker
+    id::Int
+end
+
+function get_workers()
+    map(DistributedNextWorker, workers())
+end
+
+function Revise.remotecall_impl(f, worker::DistributedNextWorker, args...; kwargs...)
+    remotecall(f, worker.id, args...; kwargs...)
+end
+
+Revise.is_master_worker(::typeof(get_workers)) = myid() == 1
+Revise.is_master_worker(worker::DistributedNextWorker) = worker.id == 1
+
+function __init__()
+    Revise.register_workers_function(get_workers)
+    DistributedNext.add_worker_added_callback(pid -> Revise.init_worker(DistributedNextWorker(pid));
+                                              key="DistributedNext-integration")
+end
+
+end

--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -1185,7 +1185,7 @@ function deregister_worker(pg, pid)
             # Notify the cluster manager of this workers death
             manage(w.manager, w.id, w.config, :deregister)
             if PGRP.topology !== :all_to_all || isclusterlazy()
-                for rpid in workers()
+                for rpid in filter(!=(myid()), workers())
                     try
                         remote_do(deregister_worker, rpid, pid)
                     catch

--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -461,12 +461,14 @@ function addprocs(manager::ClusterManager; kwargs...)
 
     cluster_mgmt_from_master_check()
 
-    lock(worker_lock)
-    try
-        addprocs_locked(manager::ClusterManager; kwargs...)
-    finally
-        unlock(worker_lock)
+    new_workers = @lock worker_lock addprocs_locked(manager::ClusterManager; kwargs...)
+    for worker in new_workers
+        for callback in values(worker_added_callbacks)
+            callback(worker)
+        end
     end
+
+    return new_workers
 end
 
 function addprocs_locked(manager::ClusterManager; kwargs...)
@@ -855,12 +857,95 @@ const HDR_COOKIE_LEN=16
 const map_pid_wrkr = Dict{Int, Union{Worker, LocalProcess}}()
 const map_sock_wrkr = IdDict()
 const map_del_wrkr = Set{Int}()
+const worker_added_callbacks = Dict{Any, Base.Callable}()
+const worker_exiting_callbacks = Dict{Any, Base.Callable}()
+const worker_exited_callbacks = Dict{Any, Base.Callable}()
 
 # whether process is a master or worker in a distributed setup
 myrole() = LPROCROLE[]
 function myrole!(proctype::Symbol)
     LPROCROLE[] = proctype
 end
+
+# Callbacks
+
+# We define the callback methods in a loop here and add docstrings for them afterwards
+for callback_type in (:added, :exiting, :exited)
+    let add_name = Symbol(:add_worker_, callback_type, :_callback),
+        remove_name = Symbol(:remove_worker_, callback_type, :_callback),
+        dict_name = Symbol(:worker_, callback_type, :_callbacks)
+
+        @eval begin
+            function $add_name(f::Base.Callable; key=nothing)
+                if !hasmethod(f, Tuple{Int})
+                    throw(ArgumentError("Callback function is invalid, it must be able to accept a single Int argument"))
+                end
+
+                if isnothing(key)
+                    key = Symbol(gensym(), nameof(f))
+                end
+
+                $dict_name[key] = f
+                return key
+            end
+
+            $remove_name(key) = delete!($dict_name, key)
+        end
+    end
+end
+
+"""
+    add_worker_added_callback(f::Base.Callable; key=nothing)
+
+Register a callback to be called on the master process whenever a worker is
+added. The callback will be called with the added worker ID,
+e.g. `f(w::Int)`. Returns a unique key for the callback.
+"""
+function add_worker_added_callback end
+
+"""
+    remove_worker_added_callback(key)
+
+Remove the callback for `key`.
+"""
+function remove_worker_added_callback end
+
+"""
+    add_worker_exiting_callback(f::Base.Callable; key=nothing)
+
+Register a callback to be called on the master process immediately before a
+worker is removed with [`rmprocs()`](@ref). The callback will be called with the
+worker ID, e.g. `f(w::Int)`. Returns a unique key for the callback.
+
+All callbacks will be executed asynchronously and if they don't all finish
+before the `callback_timeout` passed to `rmprocs()` then the process will be
+removed anyway.
+"""
+function add_worker_exiting_callback end
+
+"""
+    remove_worker_exiting_callback(key)
+
+Remove the callback for `key`.
+"""
+function remove_worker_exiting_callback end
+
+"""
+    add_worker_exited_callback(f::Base.Callable; key=nothing)
+
+Register a callback to be called on the master process when a worker has exited
+for any reason (i.e. not only because of [`rmprocs()`](@ref) but also the worker
+segfaulting etc). The callback will be called with the worker ID,
+e.g. `f(w::Int)`. Returns a unique key for the callback.
+"""
+function add_worker_exited_callback end
+
+"""
+    remove_worker_exited_callback(key)
+
+Remove the callback for `key`.
+"""
+function remove_worker_exited_callback end
 
 # cluster management related API
 """
@@ -1025,7 +1110,7 @@ function cluster_mgmt_from_master_check()
 end
 
 """
-    rmprocs(pids...; waitfor=typemax(Int))
+    rmprocs(pids...; waitfor=typemax(Int), callback_timeout=10)
 
 Remove the specified workers. Note that only process 1 can add or remove
 workers.
@@ -1038,6 +1123,10 @@ Argument `waitfor` specifies how long to wait for the workers to shut down:
     scheduled for removal in a different task. The scheduled [`Task`](@ref) object is
     returned. The user should call [`wait`](@ref) on the task before invoking any other
     parallel calls.
+
+The `callback_timeout` specifies how long to wait for any callbacks to execute
+before continuing to remove the workers (see
+[`add_worker_exiting_callback()`](@ref)).
 
 # Examples
 ```julia-repl
@@ -1055,24 +1144,36 @@ julia> workers()
  6
 ```
 """
-function rmprocs(pids...; waitfor=typemax(Int))
+function rmprocs(pids...; waitfor=typemax(Int), callback_timeout=10)
     cluster_mgmt_from_master_check()
 
     pids = vcat(pids...)
     if waitfor == 0
-        t = @async _rmprocs(pids, typemax(Int))
+        t = @async _rmprocs(pids, typemax(Int), callback_timeout)
         yield()
         return t
     else
-        _rmprocs(pids, waitfor)
+        _rmprocs(pids, waitfor, callback_timeout)
         # return a dummy task object that user code can wait on.
         return @async nothing
     end
 end
 
-function _rmprocs(pids, waitfor)
+function _rmprocs(pids, waitfor, callback_timeout)
     lock(worker_lock)
     try
+        # Run the callbacks
+        callback_tasks = Task[]
+        for pid in pids
+            for callback in values(worker_exiting_callbacks)
+                push!(callback_tasks, Threads.@spawn callback(pid))
+            end
+        end
+
+        if timedwait(() -> all(istaskdone.(callback_tasks)), callback_timeout) === :timed_out
+            @warn "Some callbacks timed out, continuing to remove workers anyway"
+        end
+
         rmprocset = Union{LocalProcess, Worker}[]
         for p in pids
             if p == 1
@@ -1218,6 +1319,14 @@ function deregister_worker(pg, pid)
             delete!(pg.refs, id)
         end
     end
+
+    # Call callbacks on the master
+    if myid() == 1
+        for callback in values(worker_exited_callbacks)
+            callback(pid)
+        end
+    end
+
     return
 end
 

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -1,5 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+import Revise
 using DistributedNext, Random, Serialization, Sockets
 import DistributedNext
 import DistributedNext: launch, manage
@@ -1968,6 +1969,69 @@ end
     @test length(exiting_workers) == 1
     @test length(exited_workers) == 1
 end
+
+# This is a simplified copy of a test from Revise.jl's tests
+@testset "Revise.jl integration" begin
+    function rm_precompile(pkgname::AbstractString)
+        filepath = Base.cache_file_entry(Base.PkgId(pkgname))
+        isa(filepath, Tuple) && (filepath = filepath[1]*filepath[2])  # Julia 1.3+
+        for depot in DEPOT_PATH
+            fullpath = joinpath(depot, filepath)
+            isfile(fullpath) && rm(fullpath)
+        end
+    end
+
+    pid = only(addprocs(1))
+
+    # Test that initialization succeeds by checking that Main.whichtt is defined
+    # on the worker, which is defined by Revise.init_worker().
+    @test timedwait(() ->remotecall_fetch(() -> hasproperty(Main, :whichtt), pid), 10) == :ok
+
+    tmpdir = mktempdir()
+    @everywhere push!(LOAD_PATH, $tmpdir)  # Don't want to share this LOAD_PATH
+
+    # Create a fake package
+    module_file = joinpath(tmpdir, "ReviseDistributed", "src", "ReviseDistributed.jl")
+    mkpath(dirname(module_file))
+    write(module_file,
+          """
+          module ReviseDistributed
+
+          f() = π
+          g(::Int) = 0
+
+          end
+          """)
+
+    # Check that we can use it
+    @everywhere using ReviseDistributed
+    for p in procs()
+        @test remotecall_fetch(ReviseDistributed.f, p)    == π
+        @test remotecall_fetch(ReviseDistributed.g, p, 1) == 0
+    end
+
+    # Test changing and deleting methods
+    write(module_file,
+          """
+          module ReviseDistributed
+
+          f() = 3.0
+
+          end
+          """)
+    Revise.revise()
+    for p in procs()
+        # We use timedwait() here because worker updates from Revise are asynchronous
+        @test timedwait(() -> remotecall_fetch(ReviseDistributed.f, p) == 3.0, 10) == :ok
+
+        @test_throws RemoteException remotecall_fetch(ReviseDistributed.g, p, 1)
+    end
+
+    rmprocs(workers())
+    rm_precompile("ReviseDistributed")
+    pop!(LOAD_PATH)
+end
+
 
 # Run topology tests last after removing all workers, since a given
 # cluster at any time only supports a single topology.

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using DistributedNext, Random, Serialization, Sockets
+import DistributedNext
 import DistributedNext: launch, manage
 
 
@@ -1925,6 +1926,47 @@ include("splitrange.jl")
             wait(rmprocs([w]))
         end
     end
+end
+
+@testset "Worker state callbacks" begin
+    if nprocs() > 1
+        rmprocs(workers())
+    end
+
+    # Smoke test to ensure that all the callbacks are executed
+    added_workers = Int[]
+    exiting_workers = Int[]
+    exited_workers = Int[]
+    added_key = DistributedNext.add_worker_added_callback(pid -> push!(added_workers, pid))
+    exiting_key = DistributedNext.add_worker_exiting_callback(pid -> push!(exiting_workers, pid))
+    exited_key = DistributedNext.add_worker_exited_callback(pid -> push!(exited_workers, pid))
+
+    pid = only(addprocs(1))
+    @test added_workers == [pid]
+    rmprocs(workers())
+    @test exiting_workers == [pid]
+    @test exited_workers == [pid]
+
+    # Remove the callbacks
+    DistributedNext.remove_worker_added_callback(added_key)
+    DistributedNext.remove_worker_exiting_callback(exiting_key)
+    DistributedNext.remove_worker_exited_callback(exited_key)
+
+    # Test that the `callback_timeout` option works
+    event = Base.Event()
+    callback_task = nothing
+    exiting_key = DistributedNext.add_worker_exiting_callback(_ -> (callback_task = current_task(); wait(event)))
+    addprocs(1)
+
+    @test_logs (:warn, r"Some callbacks timed out.+") rmprocs(workers(); callback_timeout=0.5)
+
+    notify(event)
+    wait(callback_task)
+
+    # Test that the previous callbacks were indeed removed
+    @test length(added_workers) == 1
+    @test length(exiting_workers) == 1
+    @test length(exited_workers) == 1
 end
 
 # Run topology tests last after removing all workers, since a given


### PR DESCRIPTION
There's a few changes in here, I would recommend reviewing each commit individually. The big ones are:
- Support for worker added/exiting/exited callbacks.
- Revise support (requires callbacks to implement it properly).

Depends on https://github.com/timholy/Revise.jl/pull/871.