### PR TITLE
Make AbstractWorkerPool methods thread-safe and more consistent

### DIFF
--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -11,6 +11,11 @@ This documents notable changes in DistributedNext.jl. The format is based on
 
 ### Fixed
 - Fixed a cause of potential hangs when exiting the process ([#16]).
+- Modified the default implementations of methods like `take!` and `wait` on
+  [`AbstractWorkerPool`](@ref) to be threadsafe and behave more consistently
+  with each other. This is technically breaking, but it's a strict bugfix to
+  correct previous inconsistent behaviour so it will still land in a minor
+  release.
 
 ### Added
 - A watcher mechanism has been added to detect when both the Distributed stdlib


### PR DESCRIPTION
Previously they did not handle dead workers in the same way. In particular `take!` would remove dead workers but none of the other methods did, leading to cases where `isready` might return true but `take!` would still block.

Now they should all be consistent with each other; except for `wait` which will block if the pool is empty, unlike `take!` which will throw an exception. This seems like a reasonable tradeoff to minimize breakage while still ensuring that 'take!() will block if wait() blocks' holds.

In theory one could put the dead worker checks in other methods like `length` and `put!`, but the checks would still need to be in `take!`/`isready` etc so it seems simpler to just acknowledge the lack of thread-safety in these methods upfront.

Fixes https://github.com/JuliaLang/Distributed.jl/issues/87. If this is merged I'll backport it to Distributed.