### PR TITLE
Document that `@spawnat :any` doesn't do load-balancing

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -56,8 +56,11 @@ end
 
 Create a closure around an expression and run the closure
 asynchronously on process `p`. Return a [`Future`](@ref) to the result.
+
 If `p` is the quoted literal symbol `:any`, then the system will pick a
-processor to use automatically.
+processor to use automatically. Using `:any` will not apply any form of
+load-balancing, consider using a [`WorkerPool`](@ref) and [`remotecall(f,
+::WorkerPool)`](@ref) if you need load-balancing.
 
 # Examples
 ```julia-repl


### PR DESCRIPTION
Instead we point users to `WorkerPool`, which will do load-balancing.

Fixes [fakebreak] https://github.com/JuliaLang/Distributed.jl/issues/76. If this is merged I'll upstream it to Distributed.