### PR TITLE
Export `remotecall_eval`

### DIFF
--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -23,6 +23,9 @@ This documents notable changes in DistributedNext.jl. The format is based on
 - [`other_workers()`](@ref) and [`other_procs()`](@ref) were implemented and
   exported ([#18]).
 
+### Changed
+- [`remotecall_eval`](@ref) is now exported ([#23]).
+
 ## [v1.0.0] - 2024-12-02
 
 ### Fixed

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,6 +23,7 @@ DistributedNext.fetch(::RemoteChannel)
 DistributedNext.remotecall(::Any, ::Integer, ::Any...)
 DistributedNext.remotecall_wait(::Any, ::Integer, ::Any...)
 DistributedNext.remotecall_fetch(::Any, ::Integer, ::Any...)
+DistributedNext.remotecall_eval
 DistributedNext.remote_do(::Any, ::Integer, ::Any...)
 DistributedNext.put!(::RemoteChannel, ::Any...)
 DistributedNext.put!(::DistributedNext.Future, ::Any)

--- a/src/DistributedNext.jl
+++ b/src/DistributedNext.jl
@@ -51,6 +51,7 @@ export
     other_procs,
     remote,
     remotecall,
+    remotecall_eval,
     remotecall_fetch,
     remotecall_wait,
     remote_do,


### PR DESCRIPTION
Backported from Distributed (CC @nickrobinson251): https://github.com/JuliaLang/Distributed.jl/pull/123

This is a fairly straight-forward change so if there's no objections I'll merge it later today.