### PR TITLE
Create workers only once in the thread-safety tests

### DIFF
--- a/test/threads.jl
+++ b/test/threads.jl
@@ -1,5 +1,5 @@
 using Test
-using DistributedNext, Base.Threads
+using DistributedNext
 using Base.Iterators: product
 
 exeflags = ("--startup-file=no",
@@ -12,7 +12,7 @@ function call_on(f, wid, tid)
         t = Task(f)
         ccall(:jl_set_task_tid, Cvoid, (Any, Cint), t, tid - 1)
         schedule(t)
-        @assert threadid(t) == tid
+        @assert Threads.threadid(t) == tid
         t
     end
 end
@@ -27,12 +27,12 @@ isfailed(rr) = fetch_from_owner(istaskfailed, rr)
 
 @testset "RemoteChannel allows put!/take! from thread other than 1" begin
     ws = ts = product(1:2, 1:2)
+
+    # We want (the default) laziness, so that we wait for `Worker.c_state`!
+    procs_added = addprocs(2; exeflags, lazy=true)
+
     @testset "from worker $w1 to $w2 via 1" for (w1, w2) in ws
         @testset "from thread $w1.$t1 to $w2.$t2" for (t1, t2) in ts
-            # We want (the default) laziness, so that we wait for `Worker.c_state`!
-            procs_added = addprocs(2; exeflags, lazy=true)
-            @everywhere procs_added using Base.Threads
-
             p1 = procs_added[w1]
             p2 = procs_added[w2]
             chan_id = first(procs_added)
@@ -57,8 +57,8 @@ isfailed(rr) = fetch_from_owner(istaskfailed, rr)
 
             @test !isfailed(send)
             @test !isfailed(recv)
-
-            rmprocs(procs_added)
         end
     end
+
+    rmprocs(procs_added)
 end


### PR DESCRIPTION
This cuts the running time down from ~1m to ~10s. It shouldn't be necessary to re-create the workers for every iteration of the inner loop.