### PR TITLE
Fix assumption of IPv4 loopback address on macOS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DistributedNext"
 uuid = "fab6aee4-877b-4bac-a744-3eca44acbb6f"
-version = "1.3.0"
+version = "1.3.1"
 
 [deps]
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,6 +7,14 @@ CurrentModule = DistributedNext
 This documents notable changes in DistributedNext.jl. The format is based on
 [Keep a Changelog](https://keepachangelog.com).
 
+## [v1.3.1] - 2026-04-20
+
+### Changed
+- Fixed an incorrect assumption in `start_worker` that the loopback `bind_addr`
+  would be IPv4, which is untrue on macOS. This fixes silent hangs during
+  precompile on macOS, and also ensures `start_worker` errors are properly
+  reported ([#68]).
+
 ## [v1.3.0] - 2026-04-06
 
 ### Changed

--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -271,7 +271,7 @@ function start_worker(out::IO, cookie::AbstractString=readline(stdin); close_std
     stderr_to_stdout && redirect_stderr(stdout)
 
     init_worker(cookie)
-    interface = IPv4(CTX[].lproc.bind_addr)
+    interface = parse(IPAddr, CTX[].lproc.bind_addr)
     if CTX[].lproc.bind_port == 0
         (port, sock) = listenany(interface, CTX[].lproc.bind_port_hint)
         CTX[].lproc.bind_port = Int(port)

--- a/src/managers.jl
+++ b/src/managers.jl
@@ -541,6 +541,7 @@ function launch(manager::LocalManager, params::Dict, launched::Array, c::Conditi
             task = Threads.@spawn @with CTX => worker_ctx begin
                 start_worker(pipe.in, cookie; close_stdin=false, stderr_to_stdout=false, exit_on_close=false)
             end
+            errormonitor(task)
 
             wconfig.io = pipe.out
             wconfig.userdata = (; ctx=worker_ctx, task, pipe)


### PR DESCRIPTION
Found when precompiling DistributedNext without Wifi on macOS - apparently `_get_interfaces` doesn't find an IPv4 loopback address (but does find one for IPv6), but `start_worker` assumed that the `bind_addr` was always IPv4.