### PR TITLE
Use LibSSH v1 for the tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,8 +18,9 @@ ReviseExt = "Revise"
 [compat]
 Aqua = "0.8"
 Distributed = "1"
-LibSSH = "0.7"
+LibSSH = "1"
 LinearAlgebra = "1"
+Pkg = "1"
 PrecompileTools = "1"
 Random = "1"
 Revise = "3.7.0"
@@ -34,7 +35,8 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 LibSSH = "00483490-30f8-4353-8aba-35b82f51f4d0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Distributed", "LibSSH", "LinearAlgebra", "Revise", "Test"]
+test = ["Aqua", "Distributed", "LinearAlgebra", "Pkg", "Revise", "Test"]

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -726,13 +726,14 @@ end
     wp = WorkerPool(workers())
     @test nworkers() == length(unique(pmap(_->myid(), wp, 1:100)))
     @test nworkers() == length(unique(remotecall_fetch(wp->pmap(_->myid(), wp, 1:100), id_other, wp)))
-    wp = WorkerPool(2:3)
-    @test sort(unique(pmap(_->myid(), wp, 1:100))) == [2,3]
+    two_workers = sort(workers())[1:2]
+    wp = WorkerPool(two_workers)
+    @test sort(unique(pmap(_->myid(), wp, 1:100))) == two_workers
     @test fetch(remotecall(myid, wp)) in wp.workers
     @test_throws RemoteException fetch(remotecall(error, wp))
 
     # wait on worker pool
-    wp = WorkerPool(2:2)
+    wp = WorkerPool(two_workers[1:1])
     w = take!(wp)
 
     # local call to _wait
@@ -987,14 +988,14 @@ f16091b = () -> 1
 
     # these will only heisen-fail, since it depends on the gensym counter collisions:
     remotecall_fetch(()->eval(:(f16091b = () -> 2)), wid)
-    @test remotecall_fetch(f16091b, 2) === 1
+    @test remotecall_fetch(f16091b, wid) === 1
     # Global anonymous functions are over-written...
     @test remotecall_fetch((myid)->remotecall_fetch(f16091b, myid), wid, myid()) === 1
 
     # ...while local anonymous functions are by definition, local.
     let
         f16091c = () -> 1
-        @test remotecall_fetch(f16091c, 2) === 1
+        @test remotecall_fetch(f16091c, wid) === 1
         @test remotecall_fetch(
             myid -> begin
                 let
@@ -1032,14 +1033,14 @@ f16091b = () -> 1
     # Deserialization error recovery test
     # locally defined module, but unavailable on workers
     let
-        @test_throws RemoteException remotecall_fetch(()->LocalFoo.foo, 2)
+        @test_throws RemoteException remotecall_fetch(()->LocalFoo.foo, wrkr1)
 
         bad_thunk = ()->NonexistentModule.f()
-        @test_throws RemoteException remotecall_fetch(bad_thunk, 2)
+        @test_throws RemoteException remotecall_fetch(bad_thunk, wrkr1)
 
         # Test that the stream is still usable
-        @test remotecall_fetch(()->:test,2) === :test
-        ref = remotecall(bad_thunk, 2)
+        @test remotecall_fetch(()->:test, wrkr1) === :test
+        ref = remotecall(bad_thunk, wrkr1)
         @test_throws RemoteException fetch(ref)
     end
 
@@ -1483,7 +1484,7 @@ v2669=10
 
     let thrown = false
         try
-            remotecall_fetch(sqrt, 2, -1)
+            remotecall_fetch(sqrt, workers()[1], -1)
         catch e
             thrown = true
             local b = IOBuffer()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,20 +10,10 @@ include(joinpath(Sys.BINDIR, "..", "share", "julia", "test", "testenv.jl"))
 
 cmd = `$test_exename $test_exeflags`
 
-# LibSSH.jl currently only works on unixes, and the latest release currently
-# doesn't pass CI on MacOS.
-if Sys.islinux()
-    # Run the SSH tests with a single thread because LibSSH.jl is not thread-safe
-    sshtestfile = joinpath(@__DIR__, "sshmanager.jl")
-    if Base.VERSION >= v"1.12-"
-        # The x,y format for threadpools requires Julia 1.9 or above.
-        # However, Julia didn't begin starting with 1 interactive thread by default until Julia 1.12
-        # So we don't need to bother with this on Julia 1.11 and earlier
-        JULIA_NUM_THREADS = "1,0"
-    else
-        JULIA_NUM_THREADS = "1"
-    end
-    run(addenv(`$cmd $sshtestfile`, "JULIA_NUM_THREADS" => "1"))
+# LibSSH.jl currently only works on unixes and v1.11+, and the latest release
+# currently doesn't pass CI on MacOS.
+if Sys.islinux() && VERSION >= v"1.11"
+    include("sshmanager.jl")
 else
     @warn "Skipping the SSH tests because this platform is not supported"
 end

--- a/test/sshmanager.jl
+++ b/test/sshmanager.jl
@@ -1,12 +1,13 @@
 using Test
 using DistributedNext
-import Sockets: getipaddr, listenany
+using Sockets: getipaddr, listenany
 
-import LibSSH as ssh
-import LibSSH.Demo: DemoServer
+# We install LibSSH manually because having it in Project.toml won't resolve on
+# Julia 1.10.
+import Pkg
+Pkg.add("LibSSH")
+using LibSSH: LibSSH as ssh, DemoServer
 
-
-include(joinpath(Sys.BINDIR, "..", "share", "julia", "test", "testenv.jl"))
 
 function test_n_remove_pids(new_pids)
     for p in new_pids


### PR DESCRIPTION
v1 is threadsafe so the SSH tests don't need to be run single-threaded anymore.